### PR TITLE
Fix endless loop in full IndexMap

### DIFF
--- a/Include/WAVM/Inline/IndexMap.h
+++ b/Include/WAVM/Inline/IndexMap.h
@@ -23,7 +23,7 @@ namespace WAVM {
 		template<typename... Args> Index add(Index failIndex, Args&&... args)
 		{
 			// If all possible indices are allocated, return failure.
-			if(map.size() > Uptr(maxIndex - minIndex + 1)) { return failIndex; }
+			if(map.size() >= Uptr(maxIndex - minIndex + 1)) { return failIndex; }
 
 			// Starting from the index after the last index to be allocated, check indices
 			// sequentially until one is found that isn't allocated.


### PR DESCRIPTION
When an IndexMap becomes full, it goes into an endless loop on add() method call instead of returning failIndex.