### PR TITLE
Fix m1 build

### DIFF
--- a/Include/WAVM/Platform/Error.h
+++ b/Include/WAVM/Platform/Error.h
@@ -4,11 +4,11 @@
 #include "WAVM/Inline/BasicTypes.h"
 
 namespace WAVM { namespace Platform {
-	WAVM_PACKED_STRUCT(struct AssertMetadata {
+	struct AssertMetadata {
 		const char* condition;
 		const char* file;
 		U32 line;
-	});
+	};
 
 	WAVM_API void handleAssertionFailure(const AssertMetadata& metadata);
 	[[noreturn]] WAVM_API void handleFatalError(const char* messageFormat,


### PR DESCRIPTION
`ld: warning: pointer not aligned at page boundary address 0x103F57FFC WAVM::Platform::getInstructionSourceByAddress(unsigned long long, WAVM::Platform::InstructionSource&)::wavmAssertMetadata`