### PR TITLE
Fix mutex order

### DIFF
--- a/Lib/Platform/POSIX/RWMutexPOSIX.cpp
+++ b/Lib/Platform/POSIX/RWMutexPOSIX.cpp
@@ -45,10 +45,10 @@ void Platform::RWMutex::unlock(LockShareability shareability)
 {
 	if(shareability == LockShareability::exclusive)
 	{
-		WAVM_ERROR_UNLESS(!pthread_rwlock_unlock((pthread_rwlock_t*)&lockData));
 #if WAVM_ENABLE_ASSERTS
 		exclusiveLockingThreadId.store(0, std::memory_order_relaxed);
 #endif
+		WAVM_ERROR_UNLESS(!pthread_rwlock_unlock((pthread_rwlock_t*)&lockData));
 	}
 	else
 	{


### PR DESCRIPTION
Don't mutate state with unlocked mutex.
[MutexPOSIX.cpp](https://github.com/soramitsu/WAVM/blob/e3248fb8b02c60bf3e1b5a0c44c338168d794902/Lib/Platform/POSIX/MutexPOSIX.cpp#L33-L48) does same.